### PR TITLE
feat: add stub for BUSL-1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+licenses/_spdx/
+.idea/

--- a/data.gen.go
+++ b/data.gen.go
@@ -60,6 +60,7 @@ var builtinLREs = []License{
 	{ID: "BSD-Protection", LRE: license_BSD_Protection_lre},
 	{ID: "BSD-Source-Code", LRE: license_BSD_Source_Code_lre},
 	{ID: "BSL-1.0", LRE: license_BSL_1_0_lre},
+	{ID: "BUSL-1.1", LRE: license_BUSL_1_1_lre},
 	{ID: "Bahyph", LRE: license_Bahyph_lre},
 	{ID: "Barr", LRE: license_Barr_lre},
 	{ID: "Beerware", LRE: license_Beerware_lre},
@@ -9186,7 +9187,7 @@ parties intellectual property rights.
 `
 const license_BSD_4_Clause_UC_lre = `
 //**
-BSD 4-Clause (Univeristy of California-Specific)
+BSD 4-Clause (University of California-Specific)
 https://spdx.org/licenses/BSD-4-Clause-UC.json
 http://www.freebsd.org/copyright/license.html
 **//
@@ -9734,6 +9735,57 @@ FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
 COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE FOR ANY DAMAGES
 OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF
 OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+`
+const license_BUSL_1_1_lre = `//**
+Business Source License 1.1
+https://spdx.org/licenses/BUSL-1.1.json
+https://mariadb.com/bsl11/
+**//
+
+Notice
+
+(( Business Source License 1.1 ))??
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
 `
 const license_Bahyph_lre = `//**
 Bahyph License

--- a/licenses/BUSL-1.1.lre
+++ b/licenses/BUSL-1.1.lre
@@ -1,0 +1,50 @@
+//**
+Business Source License 1.1
+https://spdx.org/licenses/BUSL-1.1.json
+https://mariadb.com/bsl11/
+**//
+
+Notice
+
+(( Business Source License 1.1 ))??
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.

--- a/scan.go
+++ b/scan.go
@@ -110,7 +110,6 @@ const maxCopyrightWords = 50
 // disjoint matches. If multiple licenses match a particular section of the input,
 // the earliest match is chosen so the returned coverage describes at most one
 // match for each section of the input.
-//
 func Scan(text []byte) Coverage {
 	return builtinScanner.Scan(text)
 }
@@ -163,7 +162,8 @@ func (s *Scanner) Scan(text []byte) Coverage {
 				// Only accept URLs that end before the next scan match.
 				if u := urlScanRE.FindIndex(text[w.Lo:]); u != nil && (m.Start == len(words) || int(w.Lo)+u[1] <= int(words[m.Start].Lo)) {
 					u0, u1 := int(w.Lo)+u[0], int(w.Lo)+u[1]
-					if l, ok := s.licenseURL(string(text[u0:u1])); ok {
+					checkMe := string(text[u0:u1])
+					if l, ok := s.licenseURL(checkMe); ok {
 						c.Match = append(c.Match, Match{
 							ID:    l.ID,
 							Type:  l.Type,

--- a/testdata/BUSL-1.1.t1
+++ b/testdata/BUSL-1.1.t1
@@ -1,0 +1,95 @@
+50.8%
+BUSL-1.1 2813,$
+
+License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+Parameters
+
+Licensor:             HashiCorp, Inc.
+Licensed Work:        Terraform Version 1.6.0 or later. The Licensed Work is (c) 2024
+                      HashiCorp, Inc.
+Additional Use Grant: You may make production use of the Licensed Work, provided
+                      Your use does not include offering the Licensed Work to third
+                      parties on a hosted or embedded basis in order to compete with 
+                      HashiCorp's paid version(s) of the Licensed Work. For purposes 
+                      of this license:
+
+                      A "competitive offering" is a Product that is offered to third
+                      parties on a paid basis, including through paid support 
+                      arrangements, that significantly overlaps with the capabilities 
+                      of HashiCorp's paid version(s) of the Licensed Work. If Your 
+                      Product is not a competitive offering when You first make it 
+                      generally available, it will not become a competitive offering
+                      later due to HashiCorp releasing a new version of the Licensed 
+                      Work with additional capabilities. In addition, Products that 
+                      are not provided on a paid basis are not competitive.
+
+                      "Product" means software that is offered to end users to manage 
+                      in their own environments or offered as a service on a hosted 
+                      basis.
+
+                      "Embedded" means including the source code or executable code 
+                      from the Licensed Work in a competitive offering. "Embedded" 
+                      also means packaging the competitive offering in such a way 
+                      that the Licensed Work must be accessed or downloaded for the 
+                      competitive offering to operate.
+
+                      Hosting or using the Licensed Work(s) for internal purposes 
+                      within an organization is not considered a competitive 
+                      offering. HashiCorp considers your organization to include all 
+                      of your affiliates under common control.
+
+                      For binding interpretive guidance on using HashiCorp products 
+                      under the Business Source License, please visit our FAQ. 
+                      (https://www.hashicorp.com/license-faq)
+Change Date:          Four years from the date the Licensed Work is published.
+Change License:       MPL 2.0
+
+For information about alternative licensing arrangements for the Licensed Work,
+please contact licensing@hashicorp.com.
+
+Notice
+
+Business Source License 1.1
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.


### PR DESCRIPTION
## Notes
This adds basic coverage to license check to discover the BUSL as described by HASHICORP. I think the LRE can be written a bit more generically so we can capture the `parameters` section and have a higher confidence match, but this is a first pass. We also have the option of adding a URL discovery option as well which I'm looking into.

The test case for this was awkward to write since the `testdata/README` specified that a test case could have the header:
```
90.5%
BSD 98.9% 1234,4567 [URL]
```

When I included the second percent which I assumed was a percent coverage for the offset the test would error and show that it only expected: `BSD 1234,4567 [URL]` as a valid case entry.

If this is incorrect and there is some other configuration where I can test the `%coverage` of the whole case along withthe `%coverage` of the offset I would like to set it up that way. 